### PR TITLE
feat: generate int32 values for enums

### DIFF
--- a/data/enum.go
+++ b/data/enum.go
@@ -7,17 +7,14 @@ type Enum struct {
 	// Name will be the package level unique name
 	// Nested names will concat with their parent messages so that it will remain unique
 	// This also means nested type might be a bit ugly in type script but whatever
-	Name string
-	// Due to the fact that Protos allows alias fields which is not a feature
-	// in Typescript, it's better to use string representation of it.
-	// So Values here will basically be the name of the field.
-	Values []string
+	Name   string
+	Values []int32
 }
 
 // NewEnum creates an enum instance.
 func NewEnum() *Enum {
 	return &Enum{
 		Name:   "",
-		Values: make([]string, 0),
+		Values: make([]int32, 0),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/golang/protobuf v1.4.3
 	github.com/grpc-ecosystem/grpc-gateway v1.15.2
-	github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.2
 	github.com/iancoleman/strcase v0.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.15.2 h1:HC+hWRWf+v5zTMPyoaYTKIJih+4sd4XRWmj0qlG87Co=
 github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
-github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.2 h1:BHv10jnhX3eXFxPLmNT9vr65s2poi8g60yjrQ9vaXYM=
-github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.2/go.mod h1:GEU+m9J2s3Mx7Asvl+4P4NNaqQtO0HHtxPLH9jUfuIs=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.1.2 h1:gnomlvw9tnV3ITTAxzKSgTF+8kFWcU/f+TgttpXGz1U=
@@ -117,7 +115,6 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/registry/enum.go
+++ b/registry/enum.go
@@ -23,9 +23,8 @@ func (r *Registry) analyseEnumType(fileData *data.File, packageName, fileName st
 	enumData.Name = packageIdentifier
 
 	for _, e := range enum.GetValue() {
-		enumData.Values = append(enumData.Values, e.GetName())
+		enumData.Values = append(enumData.Values, e.GetNumber())
 	}
 
 	fileData.Enums = append(fileData.Enums, enumData)
-
 }


### PR DESCRIPTION
To be used with the gateway which is configured to marshal enums as ints.