### PR TITLE
fix: properly generate enum key names

### DIFF
--- a/data/enum.go
+++ b/data/enum.go
@@ -1,5 +1,10 @@
 package data
 
+type EnumValue struct {
+	Key   string
+	Value int32
+}
+
 // Enum is the data out to render Enums in a file
 // Enums that nested inside messages will be pulled out to the top level
 // Because the way it works in typescript
@@ -8,13 +13,13 @@ type Enum struct {
 	// Nested names will concat with their parent messages so that it will remain unique
 	// This also means nested type might be a bit ugly in type script but whatever
 	Name   string
-	Values []int32
+	Values []EnumValue
 }
 
 // NewEnum creates an enum instance.
 func NewEnum() *Enum {
 	return &Enum{
 		Name:   "",
-		Values: make([]int32, 0),
+		Values: make([]EnumValue, 0),
 	}
 }

--- a/generator/template.go
+++ b/generator/template.go
@@ -24,7 +24,7 @@ const tmpl = `
 {{define "enums"}}
 {{range .}}export enum {{.Name}} {
 {{- range .Values}}
-  {{.}} = "{{.}}",
+  {{.Key}} = {{.Value}},
 {{- end}}
 }
 

--- a/registry/enum.go
+++ b/registry/enum.go
@@ -23,7 +23,10 @@ func (r *Registry) analyseEnumType(fileData *data.File, packageName, fileName st
 	enumData.Name = packageIdentifier
 
 	for _, e := range enum.GetValue() {
-		enumData.Values = append(enumData.Values, e.GetNumber())
+		enumData.Values = append(enumData.Values, data.EnumValue{
+			Key:   e.GetName(),
+			Value: e.GetNumber(),
+		})
 	}
 
 	fileData.Enums = append(fileData.Enums, enumData)


### PR DESCRIPTION
This time should be `key = value`, not `value = "value"`.