### PR TITLE
fix: properly generate types for well known types

### DIFF
--- a/data/message.go
+++ b/data/message.go
@@ -20,6 +20,8 @@ type Message struct {
 	OneOfFieldsGroups map[int32][]*Field
 	// OneOfFieldNames is the names of one of fields with same index. so that renderer can render the clearing of other fields on set.
 	OneOfFieldsNames map[int32]string
+	// TypeAlias generates type alias instead of populating the list of fields for the message.
+	TypeAlias string
 }
 
 // HasOneOfFields returns true when the message has a one of field.

--- a/generator/template.go
+++ b/generator/template.go
@@ -41,6 +41,8 @@ type Base{{.Name}} = {
 export type {{.Name}} = Base{{.Name}}
 {{range $groupId, $fields := .OneOfFieldsGroups}}  & OneOf<{ {{range $index, $field := $fields}}{{fieldName $field.Name}}: {{tsType $field}}{{if (lt (add $index 1) (len $fields))}}; {{end}}{{end}} }>
 {{end}}
+{{- else if .TypeAlias -}}
+export type {{.Name}} = {{ .TypeAlias }}
 {{- else -}}
 export type {{.Name}} = {
 {{- range .Fields}}

--- a/registry/message.go
+++ b/registry/message.go
@@ -11,6 +11,7 @@ func (r *Registry) analyseMessage(fileData *data.File, packageName, fileName str
 
 	fqName := r.getFullQualifiedName(packageName, parents, message.GetName()) // "." + packageName + "." + parentsPrefix + message.GetName()
 	protoType := descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
+	typeAlias := ""
 
 	typeInfo := &TypeInformation{
 		FullyQualifiedName: fqName,
@@ -19,6 +20,13 @@ func (r *Registry) analyseMessage(fileData *data.File, packageName, fileName str
 		PackageIdentifier:  packageIdentifier,
 		LocalIdentifier:    message.GetName(),
 		ProtoType:          protoType,
+	}
+
+	// special handling for the well known types
+	switch fqName {
+	case ".google.protobuf.Timestamp",
+		".google.protobuf.Duration":
+		typeAlias = "string"
 	}
 
 	// register itself in the registry map
@@ -55,6 +63,7 @@ func (r *Registry) analyseMessage(fileData *data.File, packageName, fileName str
 	data := data.NewMessage()
 	data.Name = packageIdentifier
 	data.FQType = fqName
+	data.TypeAlias = typeAlias
 
 	newParents := append(parents, message.GetName())
 


### PR DESCRIPTION
`google.protobuf.Timestamp` and `google.protobuf.Duration` are always encoded to string, so the generated TS types should defines strings for them.