### PR TITLE
feat: throw request errors instead of plain objects

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -272,7 +272,21 @@ const getError = async (result: Response) => {
     throw new Error(e.message);
   }
 
-  throw resp;
+  const message = resp?.message;
+  const code = resp?.code;
+
+  throw new RequestError(message || code || JSON.stringify(resp), { code });
+}
+
+export class RequestError extends Error {
+  public code?: number;
+
+  constructor(message?: string, options?: ErrorOptions & { code?: number }) {
+    super(message, options);
+
+    this.name = 'RequestError';
+    this.code = options?.code;
+  }
 }
 
 /**
@@ -620,5 +634,4 @@ func mapScalaType(protoType string) string {
 	}
 
 	return ""
-
 }


### PR DESCRIPTION
Throw RequestError instead of plain JS objects in getError. This makes it easier to check the type of an error and know where errors come from.