### PR TITLE
feat: also check for resp?.error in getError

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -272,8 +272,8 @@ const getError = async (result: Response) => {
     throw new Error(e.message);
   }
 
-  const message = resp?.message;
-  const code = resp?.code;
+  const message = resp?.error?.message ?? resp?.message;
+  const code = resp?.error?.code ?? resp?.code;
 
   throw new RequestError(message || code || JSON.stringify(resp), { code });
 }


### PR DESCRIPTION
Also check for `resp?.error` in `getError`, as it is possible that message & code are contained in a child error object in certain cases.