### PR TITLE
fix: cannot have optional param before required param

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -55,7 +55,7 @@ export type {{.Name}} = {
 {{define "services"}}{{range .}}export class {{.Name}} {
 {{- range .Methods}}  
 {{- if .ServerStreaming }}
-  static {{.Name}}(req: {{tsType .Input}}, entityNotifier?: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, ...options: fm.fetchOption[]): Promise<void> {
+  static {{.Name}}(req: {{tsType .Input}}, entityNotifier: fm.NotifyStreamEntityArrival<{{tsType .Output}}>, ...options: fm.fetchOption[]): Promise<void> {
     return fm.fetchStreamingRequest<{{tsType .Input}}, {{tsType .Output}}>({{ renderParams . }}, entityNotifier, ...options)
   }
 {{- else }}
@@ -294,7 +294,7 @@ export class RequestError extends Error {
  * it takes NotifyStreamEntityArrival that lets users respond to entity arrival during the call
  * all entities will be returned as an array after the call finishes.
  **/
-export async function fetchStreamingRequest<T, R>(method: string, path: string, body?: T, callback: NotifyStreamEntityArrival<R>, ...options: fetchOption[]): Promise<void> {
+export async function fetchStreamingRequest<T, R>(method: string, path: string, body: T, callback: NotifyStreamEntityArrival<R>, ...options: fetchOption[]): Promise<void> {
   const req = createRequest(method, path, body, ...options);
   const result = await fetch(req.url, req);
 


### PR DESCRIPTION
In `fetch.pb.ts` we are generating functions with optional parameters that have required params following them. This is not allowed in TypeScript. Vite 8 has a new bundler which complains about this even though we set `@ts-nocheck`.